### PR TITLE
fixed for building on v12

### DIFF
--- a/lib/native.js
+++ b/lib/native.js
@@ -2,7 +2,7 @@ var events = require('events');
 
 var binary = require('node-pre-gyp');
 var path = require('path');
-var binding_path = binary.find(path.resolve(path.join(__dirname,'./package.json')));
+var binding_path = binary.find(path.resolve(path.join(__dirname,'../package.json')));
 var binding = require(binding_path);
 
 var BluetoothHciSocket = binding.BluetoothHciSocket;

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
   ],
   "dependencies": {
     "debug": "^2.2.0",
-    "nan": "^2.0.5",
-    "node-pre-gyp": "0.6.x"
+    "nan": "^2.14.0",
+    "node-pre-gyp": "^0.13.0"
   },
   "optionalDependencies": {
     "usb": "^1.1.0"
@@ -37,15 +37,15 @@
     "jshint": "^2.8.0"
   },
   "scripts": {
-      "preinstall": "npm install node-pre-gyp",
-      "install": "node-pre-gyp install --fallback-to-build",
-      "test": "jshint lib/*.js"
+    "preinstall": "npm install node-pre-gyp",
+    "install": "node-pre-gyp install --fallback-to-build",
+    "test": "jshint lib/*.js"
   },
   "binary": {
-      "module_name": "binding",
-      "module_path": "./lib/binding/",
-      "host": "https://github.com/sandeepmistry/node-bluetooth-hci-socket/releases/download/",
-      "package_name": "{module_name}-{version}-{node_abi}-{platform}-{arch}.tar.gz",
-      "remote_path": "{version}"
+    "module_name": "binding",
+    "module_path": "./lib/binding/",
+    "host": "https://github.com/sandeepmistry/node-bluetooth-hci-socket/releases/download/",
+    "package_name": "{module_name}-{version}-{node_abi}-{platform}-{arch}.tar.gz",
+    "remote_path": "{version}"
   }
 }

--- a/src/BluetoothHciSocket.cpp
+++ b/src/BluetoothHciSocket.cpp
@@ -126,7 +126,7 @@ NAN_MODULE_INIT(BluetoothHciSocket::Init) {
   Nan::SetPrototypeMethod(tmpl, "stop", Stop);
   Nan::SetPrototypeMethod(tmpl, "write", Write);
 
-  target->Set(Nan::New("BluetoothHciSocket").ToLocalChecked(), tmpl->GetFunction());
+  target->Set(Nan::New("BluetoothHciSocket").ToLocalChecked(), tmpl->GetFunction(Nan::GetCurrentContext()).ToLocalChecked());
 }
 
 BluetoothHciSocket::BluetoothHciSocket() :
@@ -273,7 +273,7 @@ void BluetoothHciSocket::emitErrnoError() {
     Nan::New(strerror(errno)).ToLocalChecked()
   };
 
-  Local<Value> error = errorConstructor->NewInstance(1, constructorArgs);
+  Local<Value> error = Nan::NewInstance(errorConstructor, 1, constructorArgs).ToLocalChecked();
 
   Local<Value> argv[2] = {
     Nan::New("error").ToLocalChecked(),
@@ -393,7 +393,7 @@ NAN_METHOD(BluetoothHciSocket::BindRaw) {
   if (info.Length() > 0) {
     Local<Value> arg0 = info[0];
     if (arg0->IsInt32() || arg0->IsUint32()) {
-      devId = arg0->IntegerValue();
+      devId = arg0->IntegerValue(Nan::GetCurrentContext()).FromJust();
 
       pDevId = &devId;
     }
@@ -415,7 +415,7 @@ NAN_METHOD(BluetoothHciSocket::BindUser) {
   if (info.Length() > 0) {
     Local<Value> arg0 = info[0];
     if (arg0->IsInt32() || arg0->IsUint32()) {
-      devId = arg0->IntegerValue();
+      devId = arg0->IntegerValue(Nan::GetCurrentContext()).FromJust();
 
       pDevId = &devId;
     }


### PR DESCRIPTION
I refactored them for NodeJS v12.
As for v8 API, I referred official docs for implement.
https://v8docs.nodesource.com/node-12.0/index.html

Some functions was deprecated on v12. So I improved them for current version.